### PR TITLE
Hs/hotfix missing profile key

### DIFF
--- a/pkg/signalmeow/profile.go
+++ b/pkg/signalmeow/profile.go
@@ -267,6 +267,12 @@ func (cli *Client) DownloadUserAvatar(ctx context.Context, avatarPath string, pr
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
+	if encryptedAvatar == nil {
+		return nil, fmt.Errorf("failed to read response body: encryptedAvatar was nil")
+	}
+	if profileKey == nil {
+		return nil, fmt.Errorf("failed to read response body: profileKey was nil")
+	}
 	avatar, err := decryptBytes(profileKey[:], encryptedAvatar)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decrypt response: %w", err)

--- a/puppet.go
+++ b/puppet.go
@@ -341,6 +341,11 @@ func (puppet *Puppet) updateAvatar(ctx context.Context, source *User, info *type
 			return true
 		}
 		var err error
+		if info.ProfileKey != nil {
+			log.Err(err).
+				Msg("Failed to download new user avatar, no profile key for contact")
+			return true
+		}
 		avatarData, err = source.Client.DownloadUserAvatar(ctx, info.ProfileAvatarPath, info.ProfileKey)
 		if err != nil {
 			log.Err(err).


### PR DESCRIPTION
This is a rough fix to the problem I was seeing where we were attempting to download contact info for a contact that lacks a profile key. I'm pretty sure we should fail earlier, but this prevents it from crashing.