### PR TITLE
Restore missing metrics & remove unused ones

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -51,7 +51,6 @@ type MetricsHandler struct {
 	puppetCount             prometheus.Gauge
 	activePuppetCount       prometheus.Gauge
 	bridgeBlocked           prometheus.Gauge
-	requestCount            *prometheus.CounterVec
 	userCount               prometheus.Gauge
 	messageCount            prometheus.Gauge
 	portalCount             *prometheus.GaugeVec
@@ -109,10 +108,6 @@ func NewMetricsHandler(address string, log zerolog.Logger, db *database.Database
 			Name: "bridge_blocked",
 			Help: "Is the bridge currently blocking messages",
 		}),
-		requestCount: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "bridge_signal_request",
-			Help: "The results of signal request processing",
-		}, []string{"result", "type"}),
 		userCount: promauto.NewGauge(prometheus.GaugeOpts{
 			Name: "signal_users_total",
 			Help: "Number of Matrix users using the bridge",
@@ -202,19 +197,6 @@ func (mh *MetricsHandler) TrackConnectionState(signalID uuid.UUID, connected boo
 			mh.connected.Dec()
 		}
 	}
-}
-
-func (mh *MetricsHandler) TrackRequest(counterType string, success bool) {
-	var result string
-	if success {
-		result = "success"
-	} else {
-		result = "error"
-	}
-	mh.requestCount.With(prometheus.Labels{
-		"type":   counterType,
-		"result": result,
-	}).Inc()
 }
 
 func (mh *MetricsHandler) updateStats() {


### PR DESCRIPTION
This PR merges in https://github.com/mautrix/signal/pull/463 to work with the changes to logout handling added by https://github.com/mautrix/signal/pull/439, which is not in upstream.

It also removes a metric that was exclusive to the Element fork, the usage of which was lost since an upstream refactoring to Signal message handling (https://github.com/mautrix/signal/commit/9efe31d7893e875a73502c1a66c6f909f03f230a) and doesn't seem to be important enough to warrant being restored.